### PR TITLE
Release FSEventStream when deiniting EonilFSEventStream

### DIFF
--- a/EonilFSEventsDemoGUI/EonilFSEventsDemoGUI/ViewController.swift
+++ b/EonilFSEventsDemoGUI/EonilFSEventsDemoGUI/ViewController.swift
@@ -29,6 +29,11 @@ class ViewController: NSViewController, NSTableViewDataSource, NSTableViewDelega
             for: ObjectIdentifier(self),
             with: { [weak self] e in self?.process(fileSystemEvent: e) })
     }
+
+    override func viewDidDisappear() {
+        EonilFSEvents.stopWatching(for: ObjectIdentifier(self))
+    }
+
     deinit {
         EonilFSEvents.stopWatching(for: ObjectIdentifier(self))
     }

--- a/Sources/EonilFSEvents/EonilFSEventStream.swift
+++ b/Sources/EonilFSEvents/EonilFSEventStream.swift
@@ -145,7 +145,9 @@ public final class EonilFSEventStream {
         rawref = newRawref
     }
     deinit {
-        // `rawref` is a CFType, so will be deallocated automatically.
+        // It seems `rawref` does not get deallocated according to Instruments:
+        // Run EonilFSEventsDemoGUI via Instruments with "Leaks" and close the main window.
+        FSEventStreamRelease(self.rawref)
     }
 }
 

--- a/Sources/EonilFSEvents/EonilFSEvents.swift
+++ b/Sources/EonilFSEvents/EonilFSEvents.swift
@@ -39,7 +39,7 @@ public struct EonilFSEvents {
     }
     public static func stopWatching(for id: ObjectIdentifier) {
         assert(Thread.isMainThread)
-        assert(watchers[id] != nil)
+
         guard let s = watchers[id] else { return }
         s.stop()
         s.invalidate()


### PR DESCRIPTION
According to Instruments, see the screenshot,

<img width="1392" alt="Screenshot 2022-12-04 at 15 40 38" src="https://user-images.githubusercontent.com/460034/205497041-f7e194cd-1f3a-4264-87ef-8ab1cb2f6c82.png">

it seems that `FSEventStream` does not get deallocated when `EonilFSEventStream` is deinited. To test this, I deallocate the event stream when the main window of the Demo app is closed.